### PR TITLE
Update and fix for polars 0.46.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,13 @@ on:
     # tags-ignore:
     #   - "[0-9]+.[0-9]+.[0-9]+*"
 
+permissions:
+  contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -18,8 +25,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Set up Rust
-        run: rustup show
       - name: Free Disk Space (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: jlumbroso/free-disk-space@main
@@ -30,8 +35,15 @@ jobs:
           haskell: true
           large-packages: false
           swap-storage: true
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust_toolchain }}
+      # - uses: taiki-e/install-action@v2
+      #   with:
+      #     tool: cargo-make
       - uses: davidB/rust-cargo-make@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests
         run: cargo make --profile ci-static-code-analysis-tasks --env TARGET=${{matrix.os.target}} ci-flow
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ndarray = { version = "0.15", features = ["serde"], optional = true }
 csv = { version = "1.1", optional = true }
 rulinalg = { version = "0.4", optional = true }
 nalgebra = { version = "0.32", features = ["serde-serialize"], optional = true }
-polars = { version = "0.31", features = ["lazy"], optional = true }
+polars = { version = "0.46", features = ["lazy"], optional = true }
 
 [dev-dependencies]
 csv = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ polars = { version = "0.46", features = ["lazy"], optional = true }
 [dev-dependencies]
 csv = "1.1"
 ndarray-rand = "0.14"
+polars = { version = "0.46", features = ["csv"] }
 
 [features]
 csv = ["dep:csv"]

--- a/examples/from_polars.rs
+++ b/examples/from_polars.rs
@@ -3,8 +3,9 @@ use vega_lite_4::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // input data: a CSV reader
-    let df = CsvReader::from_path("examples/res/data/stocks.csv")?
-        .has_header(true)
+    let df = CsvReadOptions::default()
+        .with_has_header(true)
+        .try_into_reader_with_file_path(Some("examples/res/data/stocks.csv".into()))?
         .finish()?;
     let df = df
         .lazy()

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,16 +1,6 @@
 mod base_data;
 pub use base_data::*;
 
-#[cfg(feature = "nalgebra")]
-mod nalgebra_data;
-#[cfg(feature = "nalgebra")]
-pub use nalgebra_data::*;
-
-#[cfg(feature = "rulinalg")]
-mod rulinalg_data;
-#[cfg(feature = "rulinalg")]
-pub use rulinalg_data::*;
-
 #[cfg(feature = "ndarray")]
 mod ndarray_data;
 // #[cfg(feature = "ndarray")]
@@ -20,8 +10,3 @@ mod ndarray_data;
 mod csv_data;
 // #[cfg(feature = "csv")]
 // pub use csv_data::*;
-
-#[cfg(feature = "polars")]
-mod polars_data;
-#[cfg(feature = "polars")]
-pub use polars_data::*;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,12 +1,17 @@
 mod base_data;
 pub use base_data::*;
 
+#[cfg(feature = "nalgebra")]
+mod nalgebra_data;
+
+#[cfg(feature = "rulinalg")]
+mod rulinalg_data;
+
 #[cfg(feature = "ndarray")]
 mod ndarray_data;
-// #[cfg(feature = "ndarray")]
-// use ndarray_data::*;
 
 #[cfg(feature = "csv")]
 mod csv_data;
-// #[cfg(feature = "csv")]
-// pub use csv_data::*;
+
+#[cfg(feature = "polars")]
+mod polars_data;

--- a/src/data/polars_data.rs
+++ b/src/data/polars_data.rs
@@ -13,9 +13,9 @@ impl From<DataFrame> for UrlData {
         let mut iters = df
             .get_columns()
             .iter()
-            .map(|s| s.iter())
+            .map(|s| s.as_series().expect("Non empty datafarme").iter())
             .collect::<Vec<_>>();
-        let columns: Vec<&str> = df.get_column_names();
+        let columns: Vec<&str> = df.get_column_names_str();
         let mut res = vec![];
         for _ in 0..df.height() {
             let mut row = HashMap::new();
@@ -33,7 +33,7 @@ impl From<DataFrame> for UrlData {
                     AnyValue::UInt8(val) => json!(val),
                     AnyValue::Float32(val) => json!(val),
                     AnyValue::Float64(val) => json!(val),
-                    AnyValue::Utf8(val) => json!(val),
+                    AnyValue::String(val) => json!(val),
                     AnyValue::List(val) => match val.dtype() {
                         DataType::Int64 => {
                             let vec: Vec<Option<_>> = val.i64().unwrap().into_iter().collect();
@@ -75,8 +75,8 @@ impl From<DataFrame> for UrlData {
                             let vec: Vec<Option<_>> = val.f64().unwrap().into_iter().collect();
                             json!(vec)
                         }
-                        DataType::Utf8 => {
-                            let vec: Vec<Option<_>> = val.utf8().unwrap().into_iter().collect();
+                        DataType::String => {
+                            let vec: Vec<Option<_>> = val.str().unwrap().into_iter().collect();
                             json!(vec)
                         }
                         x => panic!(


### PR DESCRIPTION
Updating to 0.31 showed errors with polars-arrow so I figured we could update to latest version.
cargo buil --all-features and cargo test pass.

Regarging the fixes:
- I removed unused imports
- latest polars do not use Utf8 that is just a synonym for string
- to iterate over the row of a column, there may be a better way...
Thanks

